### PR TITLE
Remove positional argument in `warns_clear` command

### DIFF
--- a/main.py
+++ b/main.py
@@ -234,7 +234,7 @@ async def warn(ctx:SlashContext, user, reason):
         create_option(name='user', description='The person you want to remove warns from', option_type=6, required=True)
     ]
 )
-async def warn(ctx:SlashContext, user, reason):
+async def warn_clear(ctx:SlashContext, user):
     if not ctx.author.guild_permissions.manage_messages:
         raise(MissingPermissions)
     warnings[str(ctx.guild.id)][str(user.id)] = []


### PR DESCRIPTION
Removed a positional argument `reason` in `warn_clear()` , as well as a repeated command definition, which would fail slash command execution.