### PR TITLE
Add `deposit` command

### DIFF
--- a/main.py
+++ b/main.py
@@ -241,5 +241,28 @@ async def warn(ctx:SlashContext, user):
     save()
     await ctx.send(embed=discord.Embed(description=f'All warnings have been cleared for {user}.'))
 
+@slash.slash(
+    name='deposit',
+    description='Deposits a specified amount of cash into the bank.',
+    options=[
+        create_option(name='amount', description='Specify an amount to deposit (leave blank for max)', option_type=4, required=False)
+    ]
+)
+async def deposit(ctx:SlashContext, amount=None):
+    if amount == None:
+        amount = currency["wallet"][str(user.id)]
+    elif amount <= 0:
+        await ctx.reply('The amount you want to deposit must be more than `0` coins!', hidden=True)
+        return
+    elif amount > currency["wallet"][str(user.id)]:
+        await ctx.reply('The amount you want to deposit must not be more than what you have in your wallet!', hidden=True)
+        return
+    else:
+        pass
+    currency["wallet"][str(user.id)] -= int(amount)
+    currency["bank"][str(user.id)] += int(amount)
+    await ctx.send(f'You deposited `{amount}` coins to your bank account.')
+    
+
 # Initialization
 client.run(api.auth.token)

--- a/main.py
+++ b/main.py
@@ -262,6 +262,7 @@ async def deposit(ctx:SlashContext, amount=None):
     currency["wallet"][str(user.id)] -= int(amount)
     currency["bank"][str(user.id)] += int(amount)
     await ctx.send(f'You deposited `{amount}` coins to your bank account.')
+    save()
     
 
 # Initialization


### PR DESCRIPTION
Yet another enhancement to the v2 currency framework. This allows users to deposit cash to their bank account. The bank account does not have any limit (for now).
This command has some rules aswell:
- Amount cannot be less than 1.
- Float values are not supported (well even I'm not sure).
- Amount cannot be more than what the user has in their wallet.
- The positional `amount` argument may be left blank. This will result in depositing max amount of coins in bank account.