### PR TITLE
Add `withdraw` command

### DIFF
--- a/main.py
+++ b/main.py
@@ -242,28 +242,6 @@ async def warn(ctx:SlashContext, user):
     await ctx.send(embed=discord.Embed(description=f'All warnings have been cleared for {user}.'))
 
 @slash.slash(
-    name='deposit',
-    description='Deposits a specified amount of cash into the bank.',
-    options=[
-        create_option(name='amount', description='Specify an amount to deposit (leave blank for max)', option_type=4, required=False)
-    ]
-)
-async def deposit(ctx:SlashContext, amount=None):
-    if amount == None:
-        amount = currency["wallet"][str(user.id)]
-    elif amount <= 0:
-        await ctx.reply('The amount you want to deposit must be more than `0` coins!', hidden=True)
-        return
-    elif amount > currency["wallet"][str(user.id)]:
-        await ctx.reply('The amount you want to deposit must not be more than what you have in your wallet!', hidden=True)
-        return
-    else:
-        pass
-    currency["wallet"][str(user.id)] -= int(amount)
-    currency["bank"][str(user.id)] += int(amount)
-    await ctx.send(f'You deposited `{amount}` coins to your bank account.')
-
-@slash.slash(
     name='withdraw',
     description='Withdraws a specified amount of cash from the bank.',
     options=[

--- a/main.py
+++ b/main.py
@@ -241,5 +241,51 @@ async def warn(ctx:SlashContext, user):
     save()
     await ctx.send(embed=discord.Embed(description=f'All warnings have been cleared for {user}.'))
 
+@slash.slash(
+    name='deposit',
+    description='Deposits a specified amount of cash into the bank.',
+    options=[
+        create_option(name='amount', description='Specify an amount to deposit (leave blank for max)', option_type=4, required=False)
+    ]
+)
+async def deposit(ctx:SlashContext, amount=None):
+    if amount == None:
+        amount = currency["wallet"][str(user.id)]
+    elif amount <= 0:
+        await ctx.reply('The amount you want to deposit must be more than `0` coins!', hidden=True)
+        return
+    elif amount > currency["wallet"][str(user.id)]:
+        await ctx.reply('The amount you want to deposit must not be more than what you have in your wallet!', hidden=True)
+        return
+    else:
+        pass
+    currency["wallet"][str(user.id)] -= int(amount)
+    currency["bank"][str(user.id)] += int(amount)
+    await ctx.send(f'You deposited `{amount}` coins to your bank account.')
+
+@slash.slash(
+    name='withdraw',
+    description='Withdraws a specified amount of cash from the bank.',
+    options=[
+        create_option(name='amount', description='Specify an amount to withdraw (leave blank for max)', option_type=4, required=False)
+    ]
+)
+async def withdraw(ctx:SlashContext, amount=None):
+    if amount == None:
+        amount = currency["bank"][str(user.id)]
+    elif amount <= 0:
+        await ctx.reply('The amount you want to withdraw must be more than `0` coins!', hidden=True)
+        return
+    elif amount > currency["bank"][str(user.id)]:
+        await ctx.reply('The amount you want to withdraw must not be more than what you have in your bank account!', hidden=True)
+        return
+    else:
+        pass
+    currency["wallet"][str(user.id)] += int(amount)
+    currency["bank"][str(user.id)] -= int(amount)
+    await ctx.send(f'You withdrew `{amount}` coins from your bank account.')
+    save()
+    
+
 # Initialization
 client.run(api.auth.token)


### PR DESCRIPTION
Again, another update to the v2 currency framework. This allows users to withdraw cash from their bank account. There is currently no wallet cap.
This command has some rules aswell:

- Amount cannot be less than 1.
- Float values are not supported (well even I'm not sure).
- Amount cannot be more than what the user has in their bank account.
- The positional amount argument may be left blank. This will result in withdrawing max amount of coins in wallet.